### PR TITLE
Ignore README files and add separate build/deploy and test build workflows.

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,15 +1,18 @@
 name: Build and deploy the main site to github pages
-on: [push]
+on: 
+  push:
+    branches:
+      - 'main'
 jobs:
-  build-and-deploy:
+  build-and-deploy: # Builds and deploys the documentation build, only if pushed to main branch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
 
-      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+      - name: Install and Build 🔧 
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install setuptools

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,21 @@
+name: Test the documentation build
+on: 
+  push:
+    branches:
+      - '!main'
+jobs:
+  build-and-deploy: # Builds the documentation on any branch.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧 
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install setuptools
+          python3 -m pip install -r requirements.txt
+          git clone https://github.com/flashreads/blogs.git docs
+          python3 -m mkdocs build -d public

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,3 +7,10 @@ markdown_extensions:
   - meta
   - codehilite
   - admonition
+plugins:
+  - exclude:
+      glob:
+        - template.md
+      regex:
+        - "^[^/]+/(README|readme)\\.(md|MD)$"
+        - "^[^/]+/([^/]+/)+(README|readme)\\.(md|MD)$"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mkdocs==1.1.2
 mkdocs-material==6.0.2
+mkdocs-exclude==1.0.2


### PR DESCRIPTION
* Adds plugin to mkdocs to ignore the readme files in the blogs (except for the main README file)
* Adds separate workflow to test the build per branch (except main)
* Sets the build+deploy of the site to run only on main branch.